### PR TITLE
refactor: switch to use peer_id for send and recv

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
-use std::{net::SocketAddr, time::Duration};
+use std::{net::SocketAddr, str::FromStr, time::Duration};
 
-use atm0s_small_p2p::{P2pNetwork, P2pNetworkConfig};
+use atm0s_small_p2p::{P2pNetwork, P2pNetworkConfig, PeerAddress};
 use clap::Parser;
 use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
@@ -13,12 +13,16 @@ pub const DEFAULT_CLUSTER_KEY: &[u8] = include_bytes!("../certs/dev.cluster.key"
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// UDP/TCP port for serving QUIC/TCP connection for SDN network
-    #[arg(env, long, default_value = "127.0.0.1:11111")]
+    #[arg(env, long, default_value_t = 1)]
+    sdn_peer_id: u64,
+
+    /// UDP/TCP port for serving QUIC/TCP connection for SDN network
+    #[arg(env, long, default_value = "0.0.0.0:11111")]
     sdn_listener: SocketAddr,
 
     /// Seeds
     #[arg(env, long, value_delimiter = ',')]
-    sdn_seeds: Vec<SocketAddr>,
+    sdn_seeds: Vec<String>,
 
     /// Allow it broadcast address to other peers
     /// This allows other peer can active connect to this node
@@ -44,8 +48,9 @@ async fn main() {
     let cert = CertificateDer::from(DEFAULT_CLUSTER_CERT.to_vec());
 
     let mut p2p = P2pNetwork::new(P2pNetworkConfig {
-        addr: args.sdn_listener,
-        advertise: args.sdn_advertise_address,
+        peer_id: args.sdn_peer_id.into(),
+        listen_addr: args.sdn_listener,
+        advertise: args.sdn_advertise_address.map(|a| a.into()),
         priv_key: key,
         cert: cert,
         tick_ms: 100,
@@ -53,11 +58,13 @@ async fn main() {
     .await
     .expect("should create network");
 
+    let sdn_seeds = args.sdn_seeds.into_iter().map(|s| PeerAddress::from_str(s.as_str()).expect("should parse address")).collect::<Vec<_>>();
+
     let requester = p2p.requester();
     tokio::spawn(async move {
         loop {
-            for seed in &args.sdn_seeds {
-                requester.try_connect((*seed).into());
+            for seed in &sdn_seeds {
+                requester.try_connect(seed.clone());
             }
             tokio::time::sleep(Duration::from_secs(1)).await;
         }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -7,17 +7,17 @@ use tokio::sync::mpsc::Sender;
 
 use crate::{
     msg::{BroadcastMsgId, P2pServiceId, PeerMessage},
-    peer::PeerAlias,
+    peer::PeerConnectionAlias,
     router::{RouteAction, SharedRouterTable},
     service::P2pServiceEvent,
     stream::P2pQuicStream,
     utils::ErrorExt,
-    PeerAddress,
+    ConnectionId, PeerId,
 };
 
 #[derive(Debug)]
 struct SharedCtxInternal {
-    peers: HashMap<PeerAddress, PeerAlias>,
+    conns: HashMap<ConnectionId, PeerConnectionAlias>,
     received_broadcast_msg: LruCache<BroadcastMsgId, ()>,
     services: [Option<Sender<P2pServiceEvent>>; 256],
 }
@@ -32,20 +32,20 @@ impl SharedCtxInternal {
         self.services[**service_id as usize].clone()
     }
 
-    fn register_peer(&mut self, peer: PeerAddress, alias: PeerAlias) {
-        self.peers.insert(peer, alias);
+    fn register_conn(&mut self, conn: ConnectionId, alias: PeerConnectionAlias) {
+        self.conns.insert(conn, alias);
     }
 
-    fn unregister_peer(&mut self, peer: &PeerAddress) {
-        self.peers.remove(peer);
+    fn unregister_conn(&mut self, conn: &ConnectionId) {
+        self.conns.remove(conn);
     }
 
-    fn peer(&self, peer: &PeerAddress) -> Option<PeerAlias> {
-        self.peers.get(peer).cloned()
+    fn conn(&self, conn: &ConnectionId) -> Option<PeerConnectionAlias> {
+        self.conns.get(conn).cloned()
     }
 
-    fn peers(&self) -> Vec<PeerAlias> {
-        self.peers.values().cloned().collect::<Vec<_>>()
+    fn conns(&self) -> Vec<PeerConnectionAlias> {
+        self.conns.values().cloned().collect::<Vec<_>>()
     }
 
     /// check if we already got the message
@@ -71,7 +71,7 @@ impl SharedCtx {
     pub fn new(router: SharedRouterTable) -> Self {
         Self {
             ctx: Arc::new(RwLock::new(SharedCtxInternal {
-                peers: Default::default(),
+                conns: Default::default(),
                 received_broadcast_msg: LruCache::new(8192.try_into().expect("should ok")),
                 services: std::array::from_fn(|_| None),
             })),
@@ -83,20 +83,20 @@ impl SharedCtx {
         self.ctx.write().set_service(service_id, tx);
     }
 
-    pub fn register_peer(&self, peer: PeerAddress, alias: PeerAlias) {
-        self.ctx.write().register_peer(peer, alias);
+    pub fn register_conn(&self, conn: ConnectionId, alias: PeerConnectionAlias) {
+        self.ctx.write().register_conn(conn, alias);
     }
 
-    pub fn unregister_peer(&self, peer: &PeerAddress) {
-        self.ctx.write().unregister_peer(peer);
+    pub fn unregister_conn(&self, conn: &ConnectionId) {
+        self.ctx.write().unregister_conn(conn);
     }
 
-    pub fn peer(&self, peer: &PeerAddress) -> Option<PeerAlias> {
-        self.ctx.read().peer(peer)
+    pub fn conn(&self, conn: &ConnectionId) -> Option<PeerConnectionAlias> {
+        self.ctx.read().conn(conn)
     }
 
-    pub fn peers(&self) -> Vec<PeerAlias> {
-        self.ctx.read().peers()
+    pub fn conns(&self) -> Vec<PeerConnectionAlias> {
+        self.ctx.read().conns()
     }
 
     pub fn router(&self) -> &SharedRouterTable {
@@ -114,29 +114,29 @@ impl SharedCtx {
         self.ctx.write().check_broadcast_msg(id)
     }
 
-    pub fn try_send_unicast(&self, service_id: P2pServiceId, dest: PeerAddress, data: Vec<u8>) -> anyhow::Result<()> {
+    pub fn try_send_unicast(&self, service_id: P2pServiceId, dest: PeerId, data: Vec<u8>) -> anyhow::Result<()> {
         let next = self.router.action(&dest).ok_or(anyhow!("route not found"))?;
         match next {
             RouteAction::Local => {
                 panic!("unsupported send to local node")
             }
             RouteAction::Next(next) => {
-                let source = self.router.local_address();
-                self.peer(&next).ok_or(anyhow!("peer not found"))?.try_send(PeerMessage::Unicast(source, dest, service_id, data))?;
+                let source = self.router.local_id();
+                self.conn(&next).ok_or(anyhow!("peer not found"))?.try_send(PeerMessage::Unicast(source, dest, service_id, data))?;
                 Ok(())
             }
         }
     }
 
-    pub async fn send_unicast(&self, service_id: P2pServiceId, dest: PeerAddress, data: Vec<u8>) -> anyhow::Result<()> {
+    pub async fn send_unicast(&self, service_id: P2pServiceId, dest: PeerId, data: Vec<u8>) -> anyhow::Result<()> {
         let next = self.router.action(&dest).ok_or(anyhow!("route not found"))?;
         match next {
             RouteAction::Local => {
                 panic!("unsupported send to local node")
             }
             RouteAction::Next(next) => {
-                let source = self.router.local_address();
-                self.peer(&next).ok_or(anyhow!("peer not found"))?.send(PeerMessage::Unicast(source, dest, service_id, data)).await?;
+                let source = self.router.local_id();
+                self.conn(&next).ok_or(anyhow!("peer not found"))?.send(PeerMessage::Unicast(source, dest, service_id, data)).await?;
                 Ok(())
             }
         }
@@ -145,11 +145,12 @@ impl SharedCtx {
     pub fn try_send_broadcast(&self, service_id: P2pServiceId, data: Vec<u8>) {
         let msg_id = BroadcastMsgId::rand();
         self.check_broadcast_msg(msg_id);
-        let source = self.router.local_address();
-        let peers = self.peers();
-        log::debug!("[ShareCtx] broadcast to {peers:?} nodes");
-        for peer in peers {
-            peer.try_send(PeerMessage::Broadcast(source, service_id, msg_id, data.clone()))
+        let source = self.router.local_id();
+        let conns = self.conns();
+        log::debug!("[ShareCtx] broadcast to {conns:?} connections");
+        for conn_alias in conns {
+            conn_alias
+                .try_send(PeerMessage::Broadcast(source, service_id, msg_id, data.clone()))
                 .print_on_err("[ShareCtx] broadcast data over peer alias");
         }
     }
@@ -157,25 +158,26 @@ impl SharedCtx {
     pub async fn send_broadcast(&self, service_id: P2pServiceId, data: Vec<u8>) {
         let msg_id = BroadcastMsgId::rand();
         self.check_broadcast_msg(msg_id);
-        let source = self.router.local_address();
-        let peers = self.peers();
-        log::debug!("[ShareCtx] broadcast to {peers:?} nodes");
-        for peer in peers {
-            peer.send(PeerMessage::Broadcast(source, service_id, msg_id, data.clone()))
+        let source = self.router.local_id();
+        let conns = self.conns();
+        log::debug!("[ShareCtx] broadcast to {conns:?} connections");
+        for conn_alias in conns {
+            conn_alias
+                .send(PeerMessage::Broadcast(source, service_id, msg_id, data.clone()))
                 .await
                 .print_on_err("[ShareCtx] broadcast data over peer alias");
         }
     }
 
-    pub async fn open_stream(&self, service: P2pServiceId, dest: PeerAddress, meta: Vec<u8>) -> anyhow::Result<P2pQuicStream> {
+    pub async fn open_stream(&self, service: P2pServiceId, dest: PeerId, meta: Vec<u8>) -> anyhow::Result<P2pQuicStream> {
         let next = self.router.action(&dest).ok_or(anyhow!("route not found"))?;
         match next {
             RouteAction::Local => {
                 panic!("unsupported open_stream to local node")
             }
             RouteAction::Next(next) => {
-                let source = self.router.local_address();
-                Ok(self.peer(&next).ok_or(anyhow!("peer not found"))?.open_stream(service, source, dest, meta).await?)
+                let source = self.router.local_id();
+                Ok(self.conn(&next).ok_or(anyhow!("peer not found"))?.open_stream(service, source, dest, meta).await?)
             }
         }
     }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,7 +1,7 @@
 use derive_more::derive::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
-use super::{discovery::PeerDiscoverySync, router::RouterTableSync, PeerAddress};
+use super::{discovery::PeerDiscoverySync, router::RouterTableSync, PeerId};
 
 #[derive(Debug, Display, PartialEq, Eq, Hash, Serialize, Deserialize, Clone, Copy)]
 pub struct BroadcastMsgId(u64);
@@ -17,16 +17,15 @@ impl BroadcastMsgId {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum PeerMessage {
-    Hello {},
     Sync { route: RouterTableSync, advertise: PeerDiscoverySync },
-    Broadcast(PeerAddress, P2pServiceId, BroadcastMsgId, Vec<u8>),
-    Unicast(PeerAddress, PeerAddress, P2pServiceId, Vec<u8>),
+    Broadcast(PeerId, P2pServiceId, BroadcastMsgId, Vec<u8>),
+    Unicast(PeerId, PeerId, P2pServiceId, Vec<u8>),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StreamConnectReq {
-    pub source: PeerAddress,
-    pub dest: PeerAddress,
+    pub source: PeerId,
+    pub dest: PeerId,
     pub service: P2pServiceId,
     pub meta: Vec<u8>,
 }

--- a/src/neighbours.rs
+++ b/src/neighbours.rs
@@ -1,32 +1,32 @@
 use std::collections::HashMap;
 
-use crate::{peer::PeerConnection, PeerAddress};
+use crate::{peer::PeerConnection, ConnectionId, PeerId};
 
 #[derive(Default)]
 pub struct NetworkNeighbours {
-    peers: HashMap<PeerAddress, PeerConnection>,
+    conns: HashMap<ConnectionId, PeerConnection>,
 }
 
 impl NetworkNeighbours {
-    pub fn insert(&mut self, peer: PeerAddress, conn: PeerConnection) {
-        self.peers.insert(peer, conn);
+    pub fn insert(&mut self, conn_id: ConnectionId, conn: PeerConnection) {
+        self.conns.insert(conn_id, conn);
     }
 
-    pub fn has_peer(&self, peer: &PeerAddress) -> bool {
-        self.peers.contains_key(peer)
+    pub fn has_peer(&self, peer: &PeerId) -> bool {
+        self.conns.values().find(|c| c.peer_id().eq(&Some(*peer))).is_some()
     }
 
-    pub fn mark_connected(&mut self, peer: &PeerAddress) -> Option<()> {
-        self.peers.get_mut(peer)?.set_connected();
+    pub fn mark_connected(&mut self, conn_id: &ConnectionId, peer: PeerId) -> Option<()> {
+        self.conns.get_mut(conn_id)?.set_connected(peer);
         Some(())
     }
 
-    pub fn remove(&mut self, peer: &PeerAddress) -> Option<()> {
-        self.peers.remove(&peer)?;
+    pub fn remove(&mut self, conn_id: &ConnectionId) -> Option<()> {
+        self.conns.remove(&conn_id)?;
         Some(())
     }
 
-    pub fn connected_peers(&self) -> impl Iterator<Item = &PeerConnection> {
-        self.peers.values().into_iter().filter(|c| c.is_connected())
+    pub fn connected_conns(&self) -> impl Iterator<Item = &PeerConnection> {
+        self.conns.values().into_iter().filter(|c| c.is_connected())
     }
 }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,34 +1,42 @@
+use std::net::SocketAddr;
+
+use anyhow::anyhow;
 use peer_internal::PeerConnectionInternal;
 use quinn::{Connecting, Connection, Incoming, RecvStream, SendStream};
+use serde::{Deserialize, Serialize};
 use tokio::sync::{
-    mpsc::{channel, Receiver, Sender},
+    mpsc::{channel, Sender},
     oneshot,
 };
 
-use crate::{ctx::SharedCtx, msg::P2pServiceId, stream::P2pQuicStream, PeerAddress};
+use crate::{
+    ctx::SharedCtx,
+    msg::P2pServiceId,
+    stream::{wait_object, write_object, P2pQuicStream},
+    ConnectionId, PeerId,
+};
 
 use super::{msg::PeerMessage, InternalEvent};
 
 mod peer_alias;
 mod peer_internal;
 
-pub use peer_alias::PeerAlias;
+pub use peer_alias::PeerConnectionAlias;
 
 enum PeerConnectionControl {
     Send(PeerMessage),
-    OpenStream(P2pServiceId, PeerAddress, PeerAddress, Vec<u8>, oneshot::Sender<anyhow::Result<P2pQuicStream>>),
+    OpenStream(P2pServiceId, PeerId, PeerId, Vec<u8>, oneshot::Sender<anyhow::Result<P2pQuicStream>>),
 }
 
 pub struct PeerConnection {
-    remote: PeerAddress,
-    connected: bool,
+    conn_id: ConnectionId,
+    peer_id: Option<PeerId>,
 }
 
 impl PeerConnection {
-    pub fn new_incoming(incoming: Incoming, internal_tx: Sender<InternalEvent>, ctx: SharedCtx) -> Self {
-        let (control_tx, control_rx) = channel(10);
-        let remote: PeerAddress = incoming.remote_address().into();
-        let alias = PeerAlias::new(remote, control_tx);
+    pub fn new_incoming(local_id: PeerId, incoming: Incoming, internal_tx: Sender<InternalEvent>, ctx: SharedCtx) -> Self {
+        let remote = incoming.remote_address();
+        let conn_id = ConnectionId::rand();
 
         tokio::spawn(async move {
             log::info!("[PeerConnection] wait incoming from {remote}");
@@ -36,68 +44,118 @@ impl PeerConnection {
                 Ok(connection) => {
                     log::info!("[PeerConnection] got connection from {remote}");
                     match connection.accept_bi().await {
-                        Ok((send, recv)) => run_connection(ctx, remote, alias, connection, send, recv, internal_tx, control_rx).await,
-                        Err(err) => internal_tx.send(InternalEvent::PeerConnectError(remote, err.into())).await.expect("should send to main"),
+                        Ok((send, recv)) => {
+                            if let Err(e) = run_connection(ctx, remote, conn_id, local_id, PeerConnectionDirection::Incoming, connection, send, recv, internal_tx).await {
+                                log::error!("[PeerConnection] connection from {remote} error {e}");
+                            }
+                        }
+                        Err(err) => internal_tx.send(InternalEvent::PeerConnectError(conn_id, None, err.into())).await.expect("should send to main"),
                     }
                 }
-                Err(err) => internal_tx.send(InternalEvent::PeerConnectError(remote, err.into())).await.expect("should send to main"),
+                Err(err) => internal_tx.send(InternalEvent::PeerConnectError(conn_id, None, err.into())).await.expect("should send to main"),
             }
         });
-        Self { remote, connected: false }
+        Self { conn_id, peer_id: None }
     }
 
-    pub fn new_connecting(connecting: Connecting, internal_tx: Sender<InternalEvent>, ctx: SharedCtx) -> Self {
-        let (control_tx, control_rx) = channel(10);
-        let remote: PeerAddress = connecting.remote_address().into();
-        let alias = PeerAlias::new(remote, control_tx);
+    pub fn new_connecting(local_id: PeerId, to_peer: PeerId, connecting: Connecting, internal_tx: Sender<InternalEvent>, ctx: SharedCtx) -> Self {
+        let remote = connecting.remote_address();
+        let conn_id = ConnectionId::rand();
 
         tokio::spawn(async move {
             match connecting.await {
                 Ok(connection) => {
                     log::info!("[PeerConnection] connected to {remote}");
                     match connection.open_bi().await {
-                        Ok((send, recv)) => run_connection(ctx, remote, alias, connection, send, recv, internal_tx, control_rx).await,
-                        Err(err) => internal_tx.send(InternalEvent::PeerConnectError(remote, err.into())).await.expect("should send to main"),
+                        Ok((send, recv)) => {
+                            if let Err(e) = run_connection(ctx, remote, conn_id, local_id, PeerConnectionDirection::Outgoing(to_peer), connection, send, recv, internal_tx).await {
+                                log::error!("[PeerConnection] connection from {remote} error {e}");
+                            }
+                        }
+                        Err(err) => internal_tx
+                            .send(InternalEvent::PeerConnectError(conn_id, Some(to_peer), err.into()))
+                            .await
+                            .expect("should send to main"),
                     }
                 }
-                Err(err) => internal_tx.send(InternalEvent::PeerConnectError(remote, err.into())).await.expect("should send to main"),
+                Err(err) => internal_tx
+                    .send(InternalEvent::PeerConnectError(conn_id, Some(to_peer), err.into()))
+                    .await
+                    .expect("should send to main"),
             }
         });
-        Self { remote, connected: false }
+        Self { conn_id, peer_id: None }
     }
 
-    pub fn remote(&self) -> PeerAddress {
-        self.remote
+    pub fn conn_id(&self) -> ConnectionId {
+        self.conn_id
     }
 
-    pub fn set_connected(&mut self) {
-        self.connected = true;
+    pub fn peer_id(&self) -> Option<PeerId> {
+        self.peer_id
+    }
+
+    pub fn set_connected(&mut self, peer_id: PeerId) {
+        self.peer_id = Some(peer_id);
     }
 
     pub fn is_connected(&self) -> bool {
-        self.connected
+        self.peer_id.is_some()
     }
+}
+
+enum PeerConnectionDirection {
+    Incoming,
+    Outgoing(PeerId),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ConnectReq {
+    from: PeerId,
+    to: PeerId,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ConnectRes {
+    success: bool,
 }
 
 async fn run_connection(
     ctx: SharedCtx,
-    remote: PeerAddress,
-    alias: PeerAlias,
+    remote: SocketAddr,
+    conn_id: ConnectionId,
+    local_id: PeerId,
+    direction: PeerConnectionDirection,
     connection: Connection,
-    send: SendStream,
-    recv: RecvStream,
+    mut send: SendStream,
+    mut recv: RecvStream,
     internal_tx: Sender<InternalEvent>,
-    control_rx: Receiver<PeerConnectionControl>,
-) {
+) -> anyhow::Result<()> {
+    let to_id = if let PeerConnectionDirection::Outgoing(dest) = direction {
+        write_object::<_, _, 500>(&mut send, &ConnectReq { from: local_id, to: dest }).await?;
+        let res: ConnectRes = wait_object::<_, _, 500>(&mut recv).await?;
+        if !res.success {
+            return Err(anyhow!("destination rejected"));
+        }
+        dest
+    } else {
+        let req: ConnectReq = wait_object::<_, _, 500>(&mut recv).await?;
+        if req.to != local_id {
+            write_object::<_, _, 500>(&mut send, &ConnectRes { success: false }).await?;
+            return Err(anyhow!("destination wrong"));
+        } else {
+            write_object::<_, _, 500>(&mut send, &ConnectRes { success: true }).await?;
+            req.from
+        }
+    };
+
     let rtt_ms = connection.rtt().as_millis().min(u16::MAX as u128) as u16;
-    let mut internal = PeerConnectionInternal::new(ctx.clone(), connection.clone(), send, recv, internal_tx.clone(), control_rx);
-    if let Err(e) = internal.start().await {
-        log::error!("[PeerConnection] start {remote} response error {e}");
-        return;
-    }
+    let (control_tx, control_rx) = channel(10);
+    let alias = PeerConnectionAlias::new(local_id, to_id, conn_id, control_tx);
+    let mut internal = PeerConnectionInternal::new(ctx.clone(), conn_id, to_id, connection.clone(), send, recv, internal_tx.clone(), control_rx);
     log::info!("[PeerConnection] started {remote}, rtt: {rtt_ms}");
-    ctx.register_peer(remote, alias);
-    internal_tx.send(InternalEvent::PeerConnected(remote, rtt_ms)).await.expect("should send to main");
+    ctx.register_conn(conn_id, alias);
+    internal_tx.send(InternalEvent::PeerConnected(conn_id, to_id, rtt_ms)).await.expect("should send to main");
     log::info!("[PeerConnection] run loop for {remote}");
     loop {
         if let Err(e) = internal.recv_complex().await {
@@ -105,7 +163,8 @@ async fn run_connection(
             break;
         }
     }
-    internal_tx.send(InternalEvent::PeerDisconnected(remote)).await.expect("should send to main");
+    internal_tx.send(InternalEvent::PeerDisconnected(conn_id, to_id)).await.expect("should send to main");
     log::info!("[PeerConnection] end loop for {remote}");
-    ctx.unregister_peer(&remote);
+    ctx.unregister_conn(&conn_id);
+    Ok(())
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,6 @@
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
-use crate::{ctx::SharedCtx, msg::P2pServiceId, router::SharedRouterTable, stream::P2pQuicStream, PeerAddress};
+use crate::{ctx::SharedCtx, msg::P2pServiceId, router::SharedRouterTable, stream::P2pQuicStream, PeerId};
 
 pub mod alias_service;
 pub mod visualization_service;
@@ -9,9 +9,9 @@ const SERVICE_CHANNEL_SIZE: usize = 10;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum P2pServiceEvent {
-    Unicast(PeerAddress, Vec<u8>),
-    Broadcast(PeerAddress, Vec<u8>),
-    Stream(PeerAddress, Vec<u8>, P2pQuicStream),
+    Unicast(PeerId, Vec<u8>),
+    Broadcast(PeerId, Vec<u8>),
+    Stream(PeerId, Vec<u8>, P2pQuicStream),
 }
 
 #[derive(Debug, Clone)]
@@ -39,7 +39,7 @@ impl P2pService {
         }
     }
 
-    pub async fn send_unicast(&self, dest: PeerAddress, data: Vec<u8>) -> anyhow::Result<()> {
+    pub async fn send_unicast(&self, dest: PeerId, data: Vec<u8>) -> anyhow::Result<()> {
         self.ctx.send_unicast(self.service, dest, data).await
     }
 
@@ -47,7 +47,7 @@ impl P2pService {
         self.ctx.send_broadcast(self.service, data).await
     }
 
-    pub async fn try_send_unicast(&self, dest: PeerAddress, data: Vec<u8>) -> anyhow::Result<()> {
+    pub async fn try_send_unicast(&self, dest: PeerId, data: Vec<u8>) -> anyhow::Result<()> {
         self.ctx.try_send_unicast(self.service, dest, data)
     }
 
@@ -55,7 +55,7 @@ impl P2pService {
         self.ctx.try_send_broadcast(self.service, data)
     }
 
-    pub async fn open_stream(&self, dest: PeerAddress, meta: Vec<u8>) -> anyhow::Result<P2pQuicStream> {
+    pub async fn open_stream(&self, dest: PeerId, meta: Vec<u8>) -> anyhow::Result<P2pQuicStream> {
         self.ctx.open_stream(self.service, dest, meta).await
     }
 
@@ -69,7 +69,7 @@ impl P2pService {
 }
 
 impl P2pServiceRequester {
-    pub async fn send_unicast(&self, dest: PeerAddress, data: Vec<u8>) -> anyhow::Result<()> {
+    pub async fn send_unicast(&self, dest: PeerId, data: Vec<u8>) -> anyhow::Result<()> {
         self.ctx.send_unicast(self.service, dest, data).await
     }
 
@@ -77,7 +77,7 @@ impl P2pServiceRequester {
         self.ctx.send_broadcast(self.service, data).await
     }
 
-    pub async fn try_send_unicast(&self, dest: PeerAddress, data: Vec<u8>) -> anyhow::Result<()> {
+    pub async fn try_send_unicast(&self, dest: PeerId, data: Vec<u8>) -> anyhow::Result<()> {
         self.ctx.try_send_unicast(self.service, dest, data)
     }
 
@@ -85,7 +85,7 @@ impl P2pServiceRequester {
         self.ctx.try_send_broadcast(self.service, data)
     }
 
-    pub async fn open_stream(&self, dest: PeerAddress, meta: Vec<u8>) -> anyhow::Result<P2pQuicStream> {
+    pub async fn open_stream(&self, dest: PeerId, meta: Vec<u8>) -> anyhow::Result<P2pQuicStream> {
         self.ctx.open_stream(self.service, dest, meta).await
     }
 

--- a/src/tests/cross_nodes.rs
+++ b/src/tests/cross_nodes.rs
@@ -4,91 +4,91 @@ use test_log::test;
 
 use crate::P2pServiceEvent;
 
-use super::create_random_node;
+use super::create_node;
 
 #[test(tokio::test)]
 async fn send_direct() {
-    let (mut node1, addr1) = create_random_node(true).await;
+    let (mut node1, addr1) = create_node(true, 1).await;
     let mut service1 = node1.create_service(0.into());
     tokio::spawn(async move { while let Ok(_) = node1.recv().await {} });
 
-    let (mut node2, addr2) = create_random_node(false).await;
+    let (mut node2, addr2) = create_node(false, 2).await;
     let node2_requester = node2.requester();
     let mut service2 = node2.create_service(0.into());
     tokio::spawn(async move { while let Ok(_) = node2.recv().await {} });
 
-    node2_requester.connect(addr1).await.expect("should connect success");
+    node2_requester.connect(addr1.clone()).await.expect("should connect success");
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let data = "from_node1".as_bytes().to_vec();
-    service1.send_unicast(addr2, data.clone()).await.expect("should send ok");
-    assert_eq!(service2.recv().await, Some(P2pServiceEvent::Unicast(addr1, data)));
+    service1.send_unicast(addr2.peer_id(), data.clone()).await.expect("should send ok");
+    assert_eq!(service2.recv().await, Some(P2pServiceEvent::Unicast(addr1.peer_id(), data)));
 
     let data = "from_node2".as_bytes().to_vec();
-    service2.send_unicast(addr1, data.clone()).await.expect("should send ok");
-    assert_eq!(service1.recv().await, Some(P2pServiceEvent::Unicast(addr2, data)));
+    service2.send_unicast(addr1.peer_id(), data.clone()).await.expect("should send ok");
+    assert_eq!(service1.recv().await, Some(P2pServiceEvent::Unicast(addr2.peer_id(), data)));
 }
 
 #[test(tokio::test)]
 async fn send_error() {
     // without connect 2 peers, it should error to send data
-    let (mut node1, addr1) = create_random_node(true).await;
+    let (mut node1, addr1) = create_node(true, 1).await;
     let service1 = node1.create_service(0.into());
     tokio::spawn(async move { while let Ok(_) = node1.recv().await {} });
 
-    let (mut node2, addr2) = create_random_node(false).await;
+    let (mut node2, addr2) = create_node(false, 2).await;
     let service2 = node2.create_service(0.into());
     tokio::spawn(async move { while let Ok(_) = node2.recv().await {} });
 
     let data = "from_node1".as_bytes().to_vec();
-    assert!(service1.send_unicast(addr2, data.clone()).await.is_err());
+    assert!(service1.send_unicast(addr2.peer_id(), data.clone()).await.is_err());
 
     let data = "from_node2".as_bytes().to_vec();
-    assert!(service2.send_unicast(addr1, data.clone()).await.is_err());
+    assert!(service2.send_unicast(addr1.peer_id(), data.clone()).await.is_err());
 }
 
 #[test(tokio::test)]
 async fn send_relay() {
-    let (mut node1, addr1) = create_random_node(false).await;
+    let (mut node1, addr1) = create_node(false, 1).await;
     let mut service1 = node1.create_service(0.into());
     tokio::spawn(async move { while let Ok(_) = node1.recv().await {} });
 
-    let (mut node2, addr2) = create_random_node(false).await;
+    let (mut node2, addr2) = create_node(false, 2).await;
     let node2_requester = node2.requester();
     tokio::spawn(async move { while let Ok(_) = node2.recv().await {} });
 
-    let (mut node3, addr3) = create_random_node(false).await;
+    let (mut node3, addr3) = create_node(false, 3).await;
     let node3_requester = node3.requester();
     let mut service3 = node3.create_service(0.into());
     tokio::spawn(async move { while let Ok(_) = node3.recv().await {} });
 
-    node2_requester.connect(addr1).await.expect("should connect success");
+    node2_requester.connect(addr1.clone()).await.expect("should connect success");
     node3_requester.connect(addr2).await.expect("should connect success");
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let data = "from_node1".as_bytes().to_vec();
-    service1.send_unicast(addr3, data.clone()).await.expect("should send ok");
-    assert_eq!(service3.recv().await, Some(P2pServiceEvent::Unicast(addr1, data)));
+    service1.send_unicast(addr3.peer_id(), data.clone()).await.expect("should send ok");
+    assert_eq!(service3.recv().await, Some(P2pServiceEvent::Unicast(addr1.peer_id(), data)));
 
     let data = "from_node3".as_bytes().to_vec();
-    service3.send_unicast(addr1, data.clone()).await.expect("should send ok");
-    assert_eq!(service1.recv().await, Some(P2pServiceEvent::Unicast(addr3, data)));
+    service3.send_unicast(addr1.peer_id(), data.clone()).await.expect("should send ok");
+    assert_eq!(service1.recv().await, Some(P2pServiceEvent::Unicast(addr3.peer_id(), data)));
 }
 
 #[test(tokio::test)]
 async fn broadcast_direct() {
-    let (mut node1, addr1) = create_random_node(false).await;
+    let (mut node1, addr1) = create_node(false, 1).await;
     let mut service1 = node1.create_service(0.into());
     tokio::spawn(async move { while let Ok(_) = node1.recv().await {} });
 
-    let (mut node2, addr2) = create_random_node(false).await;
+    let (mut node2, addr2) = create_node(false, 2).await;
     let node2_requester = node2.requester();
     let mut service2 = node2.create_service(0.into());
     tokio::spawn(async move { while let Ok(_) = node2.recv().await {} });
 
-    node2_requester.connect(addr1).await.expect("should connect success");
+    node2_requester.connect(addr1.clone()).await.expect("should connect success");
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
@@ -96,46 +96,46 @@ async fn broadcast_direct() {
 
     let data = "from_node1".as_bytes().to_vec();
     service1.send_broadcast(data.clone()).await;
-    assert_eq!(service2.recv().await, Some(P2pServiceEvent::Broadcast(addr1, data)));
+    assert_eq!(service2.recv().await, Some(P2pServiceEvent::Broadcast(addr1.peer_id(), data)));
 
     let data = "from_node2".as_bytes().to_vec();
     service2.send_broadcast(data.clone()).await;
-    assert_eq!(service1.recv().await, Some(P2pServiceEvent::Broadcast(addr2, data)));
+    assert_eq!(service1.recv().await, Some(P2pServiceEvent::Broadcast(addr2.peer_id(), data)));
 }
 
 #[test(tokio::test)]
 async fn broadcast_relay() {
-    let (mut node1, addr1) = create_random_node(false).await;
+    let (mut node1, addr1) = create_node(false, 1).await;
     let mut service1 = node1.create_service(0.into());
     tokio::spawn(async move { while let Ok(_) = node1.recv().await {} });
 
-    let (mut node2, addr2) = create_random_node(false).await;
+    let (mut node2, addr2) = create_node(false, 2).await;
     let node2_requester = node2.requester();
     let mut service2 = node2.create_service(0.into());
     tokio::spawn(async move { while let Ok(_) = node2.recv().await {} });
 
-    let (mut node3, addr3) = create_random_node(false).await;
+    let (mut node3, addr3) = create_node(false, 3).await;
     let node3_requester = node3.requester();
     let mut service3 = node3.create_service(0.into());
     tokio::spawn(async move { while let Ok(_) = node3.recv().await {} });
 
-    node2_requester.connect(addr1).await.expect("should connect success");
-    node3_requester.connect(addr2).await.expect("should connect success");
+    node2_requester.connect(addr1.clone()).await.expect("should connect success");
+    node3_requester.connect(addr2.clone()).await.expect("should connect success");
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let data = "from_node1".as_bytes().to_vec();
     service1.send_broadcast(data.clone()).await;
-    assert_eq!(service2.recv().await, Some(P2pServiceEvent::Broadcast(addr1, data.clone())));
-    assert_eq!(service3.recv().await, Some(P2pServiceEvent::Broadcast(addr1, data)));
+    assert_eq!(service2.recv().await, Some(P2pServiceEvent::Broadcast(addr1.peer_id(), data.clone())));
+    assert_eq!(service3.recv().await, Some(P2pServiceEvent::Broadcast(addr1.peer_id(), data)));
 
     let data = "from_node2".as_bytes().to_vec();
     service2.send_broadcast(data.clone()).await;
-    assert_eq!(service1.recv().await, Some(P2pServiceEvent::Broadcast(addr2, data.clone())));
-    assert_eq!(service3.recv().await, Some(P2pServiceEvent::Broadcast(addr2, data)));
+    assert_eq!(service1.recv().await, Some(P2pServiceEvent::Broadcast(addr2.peer_id(), data.clone())));
+    assert_eq!(service3.recv().await, Some(P2pServiceEvent::Broadcast(addr2.peer_id(), data)));
 
     let data = "from_node3".as_bytes().to_vec();
     service3.send_broadcast(data.clone()).await;
-    assert_eq!(service1.recv().await, Some(P2pServiceEvent::Broadcast(addr3, data.clone())));
-    assert_eq!(service2.recv().await, Some(P2pServiceEvent::Broadcast(addr3, data)));
+    assert_eq!(service1.recv().await, Some(P2pServiceEvent::Broadcast(addr3.peer_id(), data.clone())));
+    assert_eq!(service2.recv().await, Some(P2pServiceEvent::Broadcast(addr3.peer_id(), data)));
 }

--- a/src/tests/visualization.rs
+++ b/src/tests/visualization.rs
@@ -4,21 +4,21 @@ use test_log::test;
 
 use crate::visualization_service::{VisualizationService, VisualizationServiceEvent};
 
-use super::create_random_node;
+use super::create_node;
 
 #[test(tokio::test)]
 async fn discovery_new_node() {
-    let (mut node1, addr1) = create_random_node(true).await;
+    let (mut node1, addr1) = create_node(true, 1).await;
     let mut service1 = VisualizationService::new(None, false, node1.create_service(0.into()));
     tokio::spawn(async move { while let Ok(_) = node1.recv().await {} });
     tokio::spawn(async move { while let Ok(_) = service1.recv().await {} });
 
-    let (mut node2, addr2) = create_random_node(false).await;
+    let (mut node2, addr2) = create_node(false, 2).await;
     let mut service2 = VisualizationService::new(Some(Duration::from_secs(1)), false, node2.create_service(0.into()));
     let node2_requester = node2.requester();
     tokio::spawn(async move { while let Ok(_) = node2.recv().await {} });
 
-    node2_requester.connect(addr1).await.expect("should connect success");
+    node2_requester.connect(addr1.clone()).await.expect("should connect success");
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let mut events = vec![
@@ -29,7 +29,8 @@ async fn discovery_new_node() {
     for event in events.iter_mut() {
         match event {
             VisualizationServiceEvent::PeerJoined(_, neighbours) | VisualizationServiceEvent::PeerUpdated(_, neighbours) => {
-                for (_, rtt) in neighbours.iter_mut() {
+                for (conn, _, rtt) in neighbours.iter_mut() {
+                    *conn = 0.into();
                     *rtt = 0;
                 }
             }
@@ -40,8 +41,8 @@ async fn discovery_new_node() {
     assert_eq!(
         events,
         vec![
-            VisualizationServiceEvent::PeerJoined(addr1, vec![(addr2, 0)]),
-            VisualizationServiceEvent::PeerUpdated(addr1, vec![(addr2, 0)]),
+            VisualizationServiceEvent::PeerJoined(addr1.peer_id(), vec![(0.into(), addr2.peer_id(), 0)]),
+            VisualizationServiceEvent::PeerUpdated(addr1.peer_id(), vec![(0.into(), addr2.peer_id(), 0)]),
         ]
     );
 }


### PR DESCRIPTION
This PR switch to use PeerId instead of PeerAddress as id of a node. Data is send with ConnectionId instead of PeerId, that allow multiple connections between two nodes.