### PR TITLE
Fix: dup outgoing conn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,7 @@ impl<SECURE: HandshakeProtocol> P2pNetwork<SECURE> {
                 Ok(P2pNetworkEvent::Continue)
             }
             InternalEvent::PeerConnectError(conn, peer, err) => {
+                self.neighbours.remove(&conn);
                 log::error!("[P2pNetwork] connection {conn} outgoing: {peer:?} error {err}");
                 Ok(P2pNetworkEvent::Continue)
             }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -69,7 +69,6 @@ impl PeerConnection {
     pub fn new_connecting<SECURE: HandshakeProtocol>(secure: Arc<SECURE>, local_id: PeerId, to_peer: PeerId, connecting: Connecting, internal_tx: Sender<InternalEvent>, ctx: SharedCtx) -> Self {
         let remote = connecting.remote_address();
         let conn_id = ConnectionId::rand();
-        let peer_id = to_peer.clone();
 
         tokio::spawn(async move {
             match connecting.await {
@@ -95,7 +94,7 @@ impl PeerConnection {
         });
         Self {
             conn_id,
-            peer_id: Some(peer_id),
+            peer_id: Some(to_peer),
             is_connected: false,
         }
     }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -33,6 +33,7 @@ enum PeerConnectionControl {
 pub struct PeerConnection {
     conn_id: ConnectionId,
     peer_id: Option<PeerId>,
+    is_connected: bool,
 }
 
 impl PeerConnection {
@@ -58,12 +59,17 @@ impl PeerConnection {
                 Err(err) => internal_tx.send(InternalEvent::PeerConnectError(conn_id, None, err.into())).await.expect("should send to main"),
             }
         });
-        Self { conn_id, peer_id: None }
+        Self {
+            conn_id,
+            peer_id: None,
+            is_connected: false,
+        }
     }
 
     pub fn new_connecting<SECURE: HandshakeProtocol>(secure: Arc<SECURE>, local_id: PeerId, to_peer: PeerId, connecting: Connecting, internal_tx: Sender<InternalEvent>, ctx: SharedCtx) -> Self {
         let remote = connecting.remote_address();
         let conn_id = ConnectionId::rand();
+        let peer_id = to_peer.clone();
 
         tokio::spawn(async move {
             match connecting.await {
@@ -87,7 +93,11 @@ impl PeerConnection {
                     .expect("should send to main"),
             }
         });
-        Self { conn_id, peer_id: None }
+        Self {
+            conn_id,
+            peer_id: Some(peer_id),
+            is_connected: false,
+        }
     }
 
     pub fn conn_id(&self) -> ConnectionId {
@@ -99,11 +109,14 @@ impl PeerConnection {
     }
 
     pub fn set_connected(&mut self, peer_id: PeerId) {
-        self.peer_id = Some(peer_id);
+        if self.peer_id.is_none() {
+            self.peer_id = Some(peer_id);
+        }
+        self.is_connected = true
     }
 
     pub fn is_connected(&self) -> bool {
-        self.peer_id.is_some()
+        self.is_connected
     }
 }
 

--- a/src/secure.rs
+++ b/src/secure.rs
@@ -67,7 +67,7 @@ impl SharedKeyHandshake {
         // Verify timestamp
         let current_ts = now_ms();
         if current_ts - handshake_data.timestamp > HANDSHAKE_TIMEOUT {
-            return Err("Handshake timeout".to_string());
+            return Err(format!("Handshake timeout {} vs {}", current_ts, handshake_data.timestamp));
         }
 
         // Verify peer IDs


### PR DESCRIPTION
I found an error that tries to create too many connections to the same peer and not be removed when timeout. 

I resolved this by:
- add the connected flag to detect the peer is connected
- add peerId to outgoing connection. It will ensure that there is only one outgoing connection simultaneously.
- remove the connection from the map when its error