### PR TITLE
feat: Implement Replicated Local Key-Value Store with Node-Local Ownership

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -5,6 +5,7 @@ use crate::{ctx::SharedCtx, msg::P2pServiceId, router::SharedRouterTable, stream
 pub mod alias_service;
 pub mod metrics_service;
 pub mod pubsub_service;
+pub mod replicate_kv_service;
 pub mod visualization_service;
 
 const SERVICE_CHANNEL_SIZE: usize = 10;

--- a/src/service/replicate_kv_service.rs
+++ b/src/service/replicate_kv_service.rs
@@ -1,0 +1,186 @@
+//!
+//! This module implement replicated local_kv which data is replicated to all nodes.
+//! Each key-value is store in local-node and broadcast to all other nodes, which allow other node can access data with local-speed.
+//! For simplicity, data is only belong to which node it created from. If a node disconnected, it's data will be deleted all other nodes.
+//! Some useful usecase: session map
+//!
+
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt::Debug,
+    hash::Hash,
+    ops::{Add, Deref, Sub},
+};
+
+use local_storage::LocalStore;
+use remote_storage::RemoteStore;
+
+mod local_storage;
+mod remote_storage;
+
+#[derive(Debug, Clone)]
+pub struct Slot<V> {
+    value: V,
+    version: Version,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Action<V> {
+    Set(V),
+    Del,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Changed<V> {
+    pub(crate) key: Key,
+    pub(crate) version: Version,
+    pub(crate) action: Action<V>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub struct Key(u64);
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Version(u64);
+
+impl Add<u64> for Version {
+    type Output = Self;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        Self(self.0 + rhs)
+    }
+}
+
+impl Sub<Version> for Version {
+    type Output = u64;
+
+    fn sub(self, rhs: Version) -> Self::Output {
+        self.0 - rhs.0
+    }
+}
+
+impl Ord for Version {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl Deref for Version {
+    type Target = u64;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub enum BroadcastEvent<V> {
+    Changed(Changed<V>),
+    Version(Version),
+}
+pub enum RpcReq {
+    FetchChanged { from: Version, to: Option<Version> },
+    FetchSnapshot,
+}
+
+pub enum RpcRes<V> {
+    FetchChanged { changes: Vec<Changed<V>>, remain: bool },
+    FetchSnapshot { slots: Vec<(Key, Slot<V>)>, version: Version },
+}
+
+pub enum KvEvent<N, V> {
+    Set(N, Key, V),
+    Del(N, Key),
+}
+
+pub enum NetEvent<N, V> {
+    Broadcast(BroadcastEvent<V>),
+    RpcReq(N, RpcReq),
+    RpcRes(N, RpcRes<V>),
+}
+
+pub enum Event<N, V> {
+    NetEvent(NetEvent<N, V>),
+    KvEvent(KvEvent<N, V>),
+}
+
+pub struct ReplicatedKvStore<N, V> {
+    remotes: HashMap<N, RemoteStore<N, V>>,
+    local: LocalStore<N, V>,
+    outs: VecDeque<Event<N, V>>,
+}
+
+impl<N, V> ReplicatedKvStore<N, V>
+where
+    N: Eq + Hash + Clone,
+    V: Debug + Eq + Clone,
+{
+    pub fn new() -> Self {
+        ReplicatedKvStore {
+            remotes: HashMap::new(),
+            local: LocalStore::new(1024),
+            outs: VecDeque::new(),
+        }
+    }
+
+    pub fn set(&mut self, key: Key, value: V) {
+        self.local.set(key.clone(), value.clone());
+        while let Some(event) = self.local.pop_out() {
+            self.outs.push_back(Event::NetEvent(event));
+        }
+    }
+
+    pub fn del(&mut self, key: Key) {
+        self.local.del(key.clone());
+        while let Some(event) = self.local.pop_out() {
+            self.outs.push_back(Event::NetEvent(event));
+        }
+    }
+
+    pub fn on_joined(&mut self, node: N) {
+        let mut remote = RemoteStore::new(node.clone());
+        while let Some(event) = remote.pop_out() {
+            self.outs.push_back(Event::NetEvent(event));
+        }
+        self.remotes.insert(node, remote);
+    }
+
+    pub fn on_left(&mut self, node: N) {
+        self.remotes.remove(&node);
+    }
+
+    pub fn on_remote_event(&mut self, from: N, event: NetEvent<N, V>) {
+        match event {
+            NetEvent::Broadcast(event) => {
+                if let Some(remote) = self.remotes.get_mut(&from) {
+                    remote.on_broadcast(event);
+                    while let Some(event) = remote.pop_out() {
+                        self.outs.push_back(Event::NetEvent(event));
+                    }
+                }
+            }
+            NetEvent::RpcReq(_, rpc_req) => {
+                self.local.on_rpc_req(from, rpc_req);
+                while let Some(event) = self.local.pop_out() {
+                    self.outs.push_back(Event::NetEvent(event));
+                }
+            }
+            NetEvent::RpcRes(_, rpc_res) => {
+                if let Some(remote) = self.remotes.get_mut(&from) {
+                    remote.on_rpc_res(rpc_res);
+                    while let Some(event) = remote.pop_out() {
+                        self.outs.push_back(Event::NetEvent(event));
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn pop(&mut self) -> Option<Event<N, V>> {
+        self.outs.pop_front()
+    }
+}

--- a/src/service/replicate_kv_service/local_storage.rs
+++ b/src/service/replicate_kv_service/local_storage.rs
@@ -1,0 +1,93 @@
+use std::collections::{BTreeMap, HashMap, VecDeque};
+
+use super::{Action, BroadcastEvent, Changed, Key, NetEvent, RpcReq, RpcRes, Slot, Version};
+
+pub struct LocalStore<N, V> {
+    slots: HashMap<Key, Slot<V>>,
+    changeds: BTreeMap<Version, Changed<V>>,
+    max_changeds: usize,
+    version: Version,
+    outs: VecDeque<NetEvent<N, V>>,
+}
+
+impl<N, V> LocalStore<N, V>
+where
+    V: Eq + Clone,
+{
+    pub fn new(max_changeds: usize) -> Self {
+        LocalStore {
+            slots: HashMap::new(),
+            changeds: BTreeMap::new(),
+            max_changeds,
+            version: Version(0),
+            outs: VecDeque::new(),
+        }
+    }
+
+    pub fn on_tick(&mut self) {
+        self.outs.push_back(NetEvent::Broadcast(BroadcastEvent::Version(self.version)));
+    }
+
+    pub fn set(&mut self, key: Key, value: V) {
+        self.version = self.version + 1;
+        let version = self.version;
+        let changed = Changed {
+            key,
+            version,
+            action: Action::Set(value.clone()),
+        };
+        self.changeds.insert(version, changed.clone());
+        self.outs.push_back(NetEvent::Broadcast(BroadcastEvent::Changed(changed)));
+        while self.changeds.len() > self.max_changeds {
+            self.changeds.pop_first();
+        }
+        self.slots.insert(key, Slot { version, value });
+    }
+
+    pub fn del(&mut self, key: Key) {
+        self.version = self.version + 1;
+        let version = self.version;
+        let changed = Changed { key, version, action: Action::Del };
+        self.changeds.insert(self.version, changed.clone());
+        self.outs.push_back(NetEvent::Broadcast(BroadcastEvent::Changed(changed)));
+        while self.changeds.len() > self.max_changeds {
+            self.changeds.pop_first();
+        }
+        self.slots.remove(&key);
+    }
+
+    pub fn on_rpc_req(&mut self, from_node: N, req: RpcReq) {
+        match req {
+            RpcReq::FetchChanged { from, to } => {
+                let changeds = self.changeds_from_to(from, to);
+                // TODO split to small parts for avoid too much data
+                let res = RpcRes::FetchChanged { changes: changeds, remain: false };
+                self.outs.push_back(NetEvent::RpcRes(from_node, res));
+            }
+            RpcReq::FetchSnapshot => {
+                let snapshot = self.snaphsot();
+                let res = RpcRes::FetchSnapshot {
+                    slots: snapshot,
+                    version: self.version,
+                };
+                self.outs.push_back(NetEvent::RpcRes(from_node, res));
+            }
+        }
+    }
+
+    pub fn changeds_from_to(&self, from: Version, to: Option<Version>) -> Vec<Changed<V>> {
+        self.changeds.range(from..=to.unwrap_or(self.version)).map(|(_, v)| v.clone()).collect()
+    }
+
+    pub fn snaphsot(&self) -> Vec<(Key, Slot<V>)> {
+        self.slots.iter().map(|(k, v)| (k.clone(), v.clone())).collect::<Vec<_>>()
+    }
+
+    pub fn version(&self) -> Version {
+        self.version
+    }
+
+    pub fn pop_out(&mut self) -> Option<NetEvent<N, V>> {
+        self.outs.pop_front()
+    }
+}

--- a/src/service/replicate_kv_service/remote_storage.rs
+++ b/src/service/replicate_kv_service/remote_storage.rs
@@ -1,0 +1,280 @@
+use std::{
+    collections::{BTreeMap, HashMap, VecDeque},
+    fmt::Debug,
+    marker::PhantomData,
+};
+
+use super::{Action, BroadcastEvent, Changed, Key, NetEvent, RpcReq, RpcRes, Slot, Version};
+
+#[derive(Debug)]
+pub enum RemoteStoreState<N, V> {
+    SyncFull(SyncFullState<N, V>),
+    SyncPart(SyncPartState<N, V>),
+    Working(WorkingState<N, V>),
+}
+
+impl<N, V> State<N, V> for RemoteStoreState<N, V>
+where
+    N: Clone,
+{
+    fn init(&mut self, ctx: &mut StateCtx<N, V>) {
+        match self {
+            RemoteStoreState::SyncFull(state) => state.init(ctx),
+            RemoteStoreState::SyncPart(state) => state.init(ctx),
+            RemoteStoreState::Working(state) => state.init(ctx),
+        }
+    }
+
+    fn on_broadcast(&mut self, ctx: &mut StateCtx<N, V>, event: BroadcastEvent<V>) {
+        match self {
+            RemoteStoreState::SyncFull(state) => state.on_broadcast(ctx, event),
+            RemoteStoreState::SyncPart(state) => state.on_broadcast(ctx, event),
+            RemoteStoreState::Working(state) => state.on_broadcast(ctx, event),
+        }
+    }
+
+    fn on_rpc_res(&mut self, ctx: &mut StateCtx<N, V>, event: RpcRes<V>) {
+        match self {
+            RemoteStoreState::SyncFull(state) => state.on_rpc_res(ctx, event),
+            RemoteStoreState::SyncPart(state) => state.on_rpc_res(ctx, event),
+            RemoteStoreState::Working(state) => state.on_rpc_res(ctx, event),
+        }
+    }
+}
+
+struct StateCtx<N, V> {
+    remote: N,
+    slots: HashMap<Key, Slot<V>>,
+    outs: VecDeque<NetEvent<N, V>>,
+    next_state: Option<RemoteStoreState<N, V>>,
+}
+
+trait State<N, V> {
+    fn init(&mut self, ctx: &mut StateCtx<N, V>);
+    fn on_broadcast(&mut self, ctx: &mut StateCtx<N, V>, event: BroadcastEvent<V>);
+    fn on_rpc_res(&mut self, ctx: &mut StateCtx<N, V>, event: RpcRes<V>);
+}
+
+pub struct RemoteStore<N, V> {
+    ctx: StateCtx<N, V>,
+    state: RemoteStoreState<N, V>,
+}
+
+impl<N, V> RemoteStore<N, V>
+where
+    N: Clone,
+    V: Debug + Eq + Clone,
+{
+    pub fn new(remote: N) -> Self {
+        let mut ctx = StateCtx {
+            remote,
+            slots: HashMap::new(),
+            outs: VecDeque::new(),
+            next_state: None,
+        };
+
+        let mut state = SyncFullState::default();
+        state.init(&mut ctx);
+
+        Self {
+            ctx,
+            state: RemoteStoreState::SyncFull(state),
+        }
+    }
+
+    pub fn on_broadcast(&mut self, event: BroadcastEvent<V>) {
+        self.state.on_broadcast(&mut self.ctx, event);
+        if let Some(mut next_state) = self.ctx.next_state.take() {
+            next_state.init(&mut self.ctx);
+            self.state = next_state;
+        }
+    }
+
+    pub fn on_rpc_res(&mut self, event: RpcRes<V>) {
+        self.state.on_rpc_res(&mut self.ctx, event);
+        if let Some(mut next_state) = self.ctx.next_state.take() {
+            next_state.init(&mut self.ctx);
+            self.state = next_state;
+        }
+    }
+
+    pub fn pop_out(&mut self) -> Option<NetEvent<N, V>> {
+        self.ctx.outs.pop_front()
+    }
+}
+
+#[derive(Debug)]
+struct SyncFullState<N, V> {
+    _tmp: PhantomData<(N, V)>,
+}
+
+impl<N, V> Default for SyncFullState<N, V> {
+    fn default() -> Self {
+        Self { _tmp: PhantomData }
+    }
+}
+
+impl<N, V> State<N, V> for SyncFullState<N, V>
+where
+    N: Clone,
+{
+    fn init(&mut self, ctx: &mut StateCtx<N, V>) {
+        ctx.slots.clear();
+        ctx.outs.push_back(NetEvent::RpcReq(ctx.remote.clone(), RpcReq::FetchSnapshot));
+    }
+
+    fn on_broadcast(&mut self, _ctx: &mut StateCtx<N, V>, _event: BroadcastEvent<V>) {
+        // dont process here
+    }
+
+    fn on_rpc_res(&mut self, ctx: &mut StateCtx<N, V>, event: RpcRes<V>) {
+        match event {
+            RpcRes::FetchChanged { .. } => {
+                // dont process here
+            }
+            RpcRes::FetchSnapshot { slots, version } => {
+                ctx.slots = slots.into_iter().collect();
+                ctx.next_state = Some(RemoteStoreState::Working(WorkingState::new(version)));
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SyncPartState<N, V> {
+    from_version: Version,
+    pendings: BTreeMap<Version, (Vec<Changed<V>>, bool)>,
+    _tmp: PhantomData<(N, V)>,
+}
+
+impl<N, V> SyncPartState<N, V> {
+    fn new(from_version: Version) -> Self {
+        Self {
+            from_version,
+            pendings: BTreeMap::new(),
+            _tmp: PhantomData,
+        }
+    }
+}
+
+impl<N, V> SyncPartState<N, V> {
+    /// we check if pendings list is continuos and start with from_version and end with remain is false
+    fn is_finished(&self) -> bool {
+        if self.pendings.is_empty() {
+            return false;
+        }
+
+        let mut coniguous = true;
+        let mut last_version = self.from_version;
+        for (version, (changes, _remain)) in &self.pendings {
+            if *version != last_version {
+                coniguous = false;
+                break;
+            }
+            last_version = changes.last().expect("must have last entry").version + 1;
+        }
+        // check if data is coniguous and last entry is finished
+        coniguous && self.pendings.last_key_value().expect("must have last entry").1 .1 == false
+    }
+}
+
+impl<N, V> State<N, V> for SyncPartState<N, V>
+where
+    N: Clone,
+{
+    fn init(&mut self, ctx: &mut StateCtx<N, V>) {
+        ctx.outs.push_back(NetEvent::RpcReq(ctx.remote.clone(), RpcReq::FetchChanged { from: self.from_version, to: None }));
+    }
+
+    fn on_broadcast(&mut self, _ctx: &mut StateCtx<N, V>, _event: BroadcastEvent<V>) {
+        // dont process here
+    }
+
+    fn on_rpc_res(&mut self, ctx: &mut StateCtx<N, V>, event: RpcRes<V>) {
+        match event {
+            RpcRes::FetchChanged { changes, remain } => {
+                if let Some(changed) = changes.first() {
+                    self.pendings.insert(changed.version, (changes, remain));
+                    if self.is_finished() {
+                        let last_version = self.pendings.last_key_value().expect("must have last entry").1 .0.last().expect("must have last entry").version;
+                        while let Some((_version, (changes, _remain))) = self.pendings.pop_first() {
+                            for changed in changes {
+                                match changed.action {
+                                    Action::Set(value) => {
+                                        ctx.slots.insert(changed.key, Slot { version: changed.version, value });
+                                    }
+                                    Action::Del => {
+                                        ctx.slots.remove(&changed.key);
+                                    }
+                                }
+                            }
+                        }
+                        ctx.next_state = Some(RemoteStoreState::Working(WorkingState::new(last_version)));
+                    }
+                } else {
+                    log::warn!("[RemoteStore:SyncPartState] empty changes received");
+                }
+            }
+            RpcRes::FetchSnapshot { .. } => {
+                // dont process here
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct WorkingState<N, V> {
+    version: Version,
+    _tmp: PhantomData<(N, V)>,
+}
+
+impl<N, V> WorkingState<N, V> {
+    fn new(version: Version) -> Self {
+        Self { version, _tmp: PhantomData }
+    }
+}
+
+impl<N, V> State<N, V> for WorkingState<N, V> {
+    fn init(&mut self, _ctx: &mut StateCtx<N, V>) {
+        // dont need init in working state
+    }
+
+    fn on_broadcast(&mut self, ctx: &mut StateCtx<N, V>, event: BroadcastEvent<V>) {
+        match event {
+            BroadcastEvent::Changed(changed) => {
+                if self.version > changed.version {
+                    // wrong data => resyncFull
+                    ctx.slots.clear();
+                    ctx.next_state = Some(RemoteStoreState::SyncFull(SyncFullState::default()));
+                } else {
+                    let delta = changed.version - self.version;
+                    if delta == 1 {
+                        // correct version
+                        self.version = changed.version;
+                        match changed.action {
+                            Action::Set(value) => {
+                                ctx.slots.insert(changed.key, Slot { version: changed.version, value });
+                            }
+                            Action::Del => {
+                                ctx.slots.remove(&changed.key);
+                            }
+                        }
+                    } else {
+                        // resync part
+                        ctx.next_state = Some(RemoteStoreState::SyncPart(SyncPartState::new(self.version + 1)));
+                    }
+                }
+            }
+            BroadcastEvent::Version(version) => {
+                if version > self.version {
+                    // resync part
+                    ctx.next_state = Some(RemoteStoreState::SyncPart(SyncPartState::new(self.version + 1)));
+                }
+            }
+        }
+    }
+
+    fn on_rpc_res(&mut self, _ctx: &mut StateCtx<N, V>, _event: RpcRes<V>) {
+        // dont process here
+    }
+}


### PR DESCRIPTION
This PR introduces a replicated local key-value store (local_kv) that distributes data across all nodes in the cluster while maintaining node-specific data ownership.

Key Features:
- Data is automatically replicated to all nodes in real-time
- Each key-value pair is created and primarily owned by its originating node
- Provides local-speed data access across the cluster
- Automatic data cleanup when a node disconnects

Use Cases:
- Distributed session management
- Temporary distributed caching
- Node-specific metadata sharing

Implementation Details:
- Broadcast mechanism ensures immediate data synchronization
- Data is automatically removed from other nodes if the originating node disconnects
- Designed for scenarios requiring fast, transient, node-local data distribution

Considerations:
- Data consistency is eventual
- Not suitable for critical or persistent data storage