### PR TITLE
Feat: add metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ blake3 = { version = "1.3" }
 tokio-util = { version = "0.7", features = ["codec"] }
 lru = { version = "0.12" }
 thiserror = { version = "2.0" }
+metrics = { version = "0.22" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -78,13 +78,15 @@ impl SharedCtxInternal {
 
 #[derive(Debug, Clone)]
 pub struct SharedCtx {
+    local_id: PeerId,
     ctx: Arc<RwLock<SharedCtxInternal>>,
     router: SharedRouterTable,
 }
 
 impl SharedCtx {
-    pub fn new(router: SharedRouterTable) -> Self {
+    pub fn new(local_id: PeerId, router: SharedRouterTable) -> Self {
         Self {
+            local_id,
             ctx: Arc::new(RwLock::new(SharedCtxInternal {
                 conns: Default::default(),
                 conn_metrics: Default::default(),
@@ -93,6 +95,10 @@ impl SharedCtx {
             })),
             router,
         }
+    }
+
+    pub fn local_id(&self) -> PeerId {
+        self.local_id
     }
 
     pub(super) fn set_service(&mut self, service_id: P2pServiceId, tx: Sender<P2pServiceEvent>) {

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -16,7 +16,8 @@ use crate::{
     now_ms,
     secure::HandshakeProtocol,
     stream::{wait_object, write_object, P2pQuicStream},
-    ConnectionId, PeerId, P2P_CONNECTION_RECV_BYTES, P2P_CONNECTION_RTT, P2P_CONNECTION_SENT_BYTES, P2P_CONNECTION_UPTIME, P2P_LIVE_CONNECTION_COUNT,
+    ConnectionId, PeerId, P2P_CONNECTION_CONGESTION_EVENTS, P2P_CONNECTION_LOST_BYTES, P2P_CONNECTION_LOST_PKT, P2P_CONNECTION_RECV_BYTES, P2P_CONNECTION_RTT, P2P_CONNECTION_SENT_BYTES,
+    P2P_CONNECTION_UPTIME, P2P_LIVE_CONNECTION_COUNT,
 };
 
 use super::{msg::PeerMessage, MainEvent};
@@ -203,5 +204,8 @@ async fn run_connection<SECURE: HandshakeProtocol>(
     counter!(P2P_CONNECTION_RTT, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).absolute(0);
     counter!(P2P_CONNECTION_SENT_BYTES, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).absolute(0);
     counter!(P2P_CONNECTION_RECV_BYTES, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).absolute(0);
+    counter!(P2P_CONNECTION_LOST_BYTES, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).absolute(0);
+    counter!(P2P_CONNECTION_LOST_PKT, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).absolute(0);
+    counter!(P2P_CONNECTION_CONGESTION_EVENTS, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).absolute(0);
     Ok(())
 }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -16,7 +16,7 @@ use crate::{
     now_ms,
     secure::HandshakeProtocol,
     stream::{wait_object, write_object, P2pQuicStream},
-    ConnectionId, PeerId, P2P_CONNECTION_PKT_LOSS, P2P_CONNECTION_RECV_BYTES, P2P_CONNECTION_RTT, P2P_CONNECTION_SENT_BYTES, P2P_CONNECTION_UPTIME, P2P_LIVE_CONNECTION_COUNT,
+    ConnectionId, PeerId, P2P_CONNECTION_RECV_BYTES, P2P_CONNECTION_RTT, P2P_CONNECTION_SENT_BYTES, P2P_CONNECTION_UPTIME, P2P_LIVE_CONNECTION_COUNT,
 };
 
 use super::{msg::PeerMessage, MainEvent};
@@ -198,10 +198,10 @@ async fn run_connection<SECURE: HandshakeProtocol>(
     log::info!("[PeerConnection {conn_id}] end loop for {remote}");
     ctx.unregister_conn(&conn_id);
     gauge!(P2P_LIVE_CONNECTION_COUNT).decrement(1);
+    gauge!(P2P_CONNECTION_RTT, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).set(0);
     counter!(P2P_CONNECTION_UPTIME, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).absolute(0);
-    gauge!(P2P_CONNECTION_PKT_LOSS, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).set(0.0);
+    counter!(P2P_CONNECTION_RTT, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).absolute(0);
     counter!(P2P_CONNECTION_SENT_BYTES, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).absolute(0);
     counter!(P2P_CONNECTION_RECV_BYTES, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).absolute(0);
-    gauge!(P2P_CONNECTION_RTT, "peer_id" => local_id.to_string(), "connect_to" => format!("{to_id}")).set(0);
     Ok(())
 }

--- a/src/secure.rs
+++ b/src/secure.rs
@@ -67,7 +67,7 @@ impl SharedKeyHandshake {
         // Verify timestamp
         let current_ts = now_ms();
         if current_ts - handshake_data.timestamp > HANDSHAKE_TIMEOUT {
-            return Err("Handshake timeout".to_string());
+            return Err(format!("Handshake timeout {} vs {}", current_ts, handshake_data.timestamp));
         }
 
         // Verify peer IDs

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -8,10 +8,12 @@ pub const P2P_ALIAS_FIND_REQUEST: &str = "p2p_alias_find_request";
 
 pub const P2P_LIVE_CONNECTION_COUNT: &str = "p2p_live_connection_count";
 pub const P2P_CONNECTION_UPTIME: &str = "p2p_connection_uptime";
-pub const P2P_CONNECTION_PKT_LOSS: &str = "p2p_connection_pkt_loss";
 pub const P2P_CONNECTION_RTT: &str = "p2p_connection_rtt";
 pub const P2P_CONNECTION_SENT_BYTES: &str = "p2p_connection_sent_bytes";
 pub const P2P_CONNECTION_RECV_BYTES: &str = "p2p_connection_recv_bytes";
+pub const P2P_CONNECTION_LOST_BYTES: &str = "p2p_connection_lost_bytes";
+pub const P2P_CONNECTION_LOST_PKT: &str = "p2p_connection_lost_pkt";
+pub const P2P_CONNECTION_CONGESTION_EVENTS: &str = "p2p_connection_congestion_events";
 
 pub fn init_metrics() {
     describe_counter!(P2P_ALIAS_CACHE_UPSERT, "Number of upserts in the alias cache");
@@ -21,9 +23,12 @@ pub fn init_metrics() {
     describe_counter!(P2P_ALIAS_FIND_REQUEST, "Number of alias find requests");
 
     describe_gauge!(P2P_LIVE_CONNECTION_COUNT, "Number of live connections");
+
     describe_counter!(P2P_CONNECTION_UPTIME, "Connection uptime");
-    describe_gauge!(P2P_CONNECTION_PKT_LOSS, "Packet loss in connection");
     describe_gauge!(P2P_CONNECTION_RTT, "Round-trip time in connection");
     describe_counter!(P2P_CONNECTION_SENT_BYTES, "Bytes sent in connection");
     describe_counter!(P2P_CONNECTION_RECV_BYTES, "Bytes received in connection");
+    describe_counter!(P2P_CONNECTION_LOST_BYTES, "Bytes lost in connection");
+    describe_counter!(P2P_CONNECTION_LOST_PKT, "Packet loss in connection");
+    describe_counter!(P2P_CONNECTION_CONGESTION_EVENTS, "Congestion events in connection");
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,29 @@
+use metrics::{describe_counter, describe_gauge};
+
+pub const P2P_ALIAS_CACHE_SIZE: &str = "p2p_alias_cache_size";
+pub const P2P_ALIAS_CACHE_UPSERT: &str = "p2p_alias_cache_upsert";
+pub const P2P_ALIAS_CACHE_POP: &str = "p2p_alias_cache_pop";
+pub const P2P_ALIAS_LIVE_FIND_REQUEST: &str = "p2p_alias_live_find_request";
+pub const P2P_ALIAS_FIND_REQUEST: &str = "p2p_alias_find_request";
+
+pub const P2P_LIVE_CONNECTION_COUNT: &str = "p2p_live_connection_count";
+pub const P2P_CONNECTION_UPTIME: &str = "p2p_connection_uptime";
+pub const P2P_CONNECTION_PKT_LOSS: &str = "p2p_connection_pkt_loss";
+pub const P2P_CONNECTION_RTT: &str = "p2p_connection_rtt";
+pub const P2P_CONNECTION_SENT_BYTES: &str = "p2p_connection_sent_bytes";
+pub const P2P_CONNECTION_RECV_BYTES: &str = "p2p_connection_recv_bytes";
+
+pub fn init_metrics() {
+    describe_counter!(P2P_ALIAS_CACHE_UPSERT, "Number of upserts in the alias cache");
+    describe_counter!(P2P_ALIAS_CACHE_POP, "Number of pops in the alias cache");
+    describe_gauge!(P2P_ALIAS_CACHE_SIZE, "Size of the alias cache");
+    describe_gauge!(P2P_ALIAS_LIVE_FIND_REQUEST, "Number of live alias find requests");
+    describe_counter!(P2P_ALIAS_FIND_REQUEST, "Number of alias find requests");
+
+    describe_gauge!(P2P_LIVE_CONNECTION_COUNT, "Number of live connections");
+    describe_counter!(P2P_CONNECTION_UPTIME, "Connection uptime");
+    describe_gauge!(P2P_CONNECTION_PKT_LOSS, "Packet loss in connection");
+    describe_gauge!(P2P_CONNECTION_RTT, "Round-trip time in connection");
+    describe_counter!(P2P_CONNECTION_SENT_BYTES, "Bytes sent in connection");
+    describe_counter!(P2P_CONNECTION_RECV_BYTES, "Bytes received in connection");
+}


### PR DESCRIPTION
I added some metrics to help monitor the node when running in production. The new metrics contain:
- Peer connection metrics include network throughput, uptime, network loss, congestion event, etc.
- Alias cache metric